### PR TITLE
Adjust fanout config to reduce downstream write throttles

### DIFF
--- a/configs/fanout/sense_stream_fanout.prod.yml
+++ b/configs/fanout/sense_stream_fanout.prod.yml
@@ -22,9 +22,9 @@ output:
 
 app_name: SenseStreamFanoutConsumerProd
 
-# grab max number of records and wait for 10 secs between reads
-max_records: 10000
-idle_time_between_reads_millis: 10000
+# grab 1000 records and wait for 5 secs between reads
+max_records: 1000
+idle_time_between_reads_millis: 5000
 
 
 trim_horizon: false


### PR DESCRIPTION
was getting a ton of write-throttles for fanout stream, batch-puts failing.
https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#metrics:graph=~(metrics~(~(~'AWS*2fKinesis~'WriteProvisionedThroughputExceeded~'StreamName~'sense_sensors_data_fanout_one))~period~60~stat~'Sum~start~'-PT3H~end~'P0D~yAxis~(left~null~right~null)~region~'us-east-1)

with 1K records and 5 sec idle-time, those throttles are gone, and batch-capacity is about 63%.

The more correct way to do this is to fix KinesisLogger to backoff gracefully. (someday)
